### PR TITLE
Add javascript and typescript to the languages with multiline comments

### DIFF
--- a/language-configuration/multi-line-configuration.json
+++ b/language-configuration/multi-line-configuration.json
@@ -7,12 +7,14 @@
     "go",
     "groovy",
     "java",
+    "javascript",
     "less",
     "objective-c",
     "objective-cpp",
     "php",
     "rust",
     "scss",
-    "swift"
+    "swift",
+    "typescript"
   ]
 }


### PR DESCRIPTION
Add javascript and typescript to the list of languages which use multiline comments.

Both languages already have auto closing pairs for `/**` so no need to add language-configuration files for them.